### PR TITLE
Directory filtering

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -83,7 +83,7 @@ limitations under the License.
         <template is="dom-repeat" items="{{displayedSpecs}}" as="spec" id="spec_list">
 
           <tr class="spec">
-            <td><b>{{spec.specName}}</b></td>
+            <td><b><a href="/{{spec.specName}}">{{spec.specName}}</a></b></td>
 
             <template is="dom-repeat" items="{{spec.results}}" as="result">
               <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
@@ -138,11 +138,19 @@ limitations under the License.
           testRuns: {
             type: Array,
           },
+          filteredDirectories: {
+            type: Array,
+            value: []
+          },
         };
       }
 
       async connectedCallback() {
         super.connectedCallback();
+
+        if (window.location.pathname !== '/') {
+          this.filteredDirectories.push(window.location.pathname)
+        }
 
         const testFileResults = await Promise.all(this.testRuns.map(testRun => {
           return this._fetchResults(testRun.results_url)
@@ -229,7 +237,14 @@ limitations under the License.
             return spec.results[key]
           })
 
-          if (this.query.length < 3) {
+          if (this.filteredDirectories.length > 0) {
+              const inFilteredDir = this.filteredDirectories.some(filterDir =>  filterDir.startsWith(`/${displaySpec.specName}`))
+              if (!inFilteredDir) {
+                continue
+              }
+          }
+
+          if (this.query.length < 3 && this.filteredDirectories.length === 0) {
             displaySpec.testFiles = []
             displayedSpecs.push(displaySpec)
             continue
@@ -252,9 +267,18 @@ limitations under the License.
 
           let matchingTestFiles = allTestFiles.filter(matchesQuery)
           if (matchingTestFiles.length > 0) {
-            displaySpec.testFiles = matchingTestFiles.slice(0, MAX_RESULTS_PER_SPEC)
+
+            if (this.filteredDirectories.length > 0) {
+              displaySpec.testFiles = matchingTestFiles
+              displaySpec.testFiles = displaySpec.testFiles.filter(tf => (
+                this.filteredDirectories.some(filterDir =>  tf.testFile.startsWith(filterDir))
+              ))
+            } else {
+              displaySpec.testFiles = matchingTestFiles.slice(0, MAX_RESULTS_PER_SPEC)
+              displaySpec.notAllTestFilesShown = matchingTestFiles.length > MAX_RESULTS_PER_SPEC
+            }
+
             displaySpec.testFiles.sort(this._testFileSort)
-            displaySpec.notAllTestFilesShown = matchingTestFiles.length > MAX_RESULTS_PER_SPEC
             displayedSpecs.push(displaySpec)
           }
         }

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -142,11 +142,11 @@ limitations under the License.
             type: Array,
             value: []
           },
-        };
+        }
       }
 
       async connectedCallback() {
-        super.connectedCallback();
+        super.connectedCallback()
 
         if (window.location.pathname !== '/') {
           this.filteredDirectories.push(window.location.pathname)
@@ -189,15 +189,15 @@ limitations under the License.
       }
 
       _testFileSort(a, b) {
-        if (a.testFile < b.testFile) return -1;
-        if (a.testFile > b.testFile) return 1;
-        return 0;
+        if (a.testFile < b.testFile) return -1
+        if (a.testFile > b.testFile) return 1
+        return 0
       }
 
       _specSort(a, b) {
-        if (a.specName < b.specName) return -1;
-        if (a.specName > b.specName) return 1;
-        return 0;
+        if (a.specName < b.specName) return -1
+        if (a.specName > b.specName) return 1
+        return 0
       }
 
       _resultWithRunIndex(results, runIndex) {
@@ -351,6 +351,6 @@ limitations under the License.
       }
     }
 
-    customElements.define(WPTResults.is, WPTResults);
+    customElements.define(WPTResults.is, WPTResults)
   </script>
 </dom-module>

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -238,7 +238,9 @@ limitations under the License.
           })
 
           if (this.filteredDirectories.length > 0) {
-              const inFilteredDir = this.filteredDirectories.some(filterDir =>  filterDir.startsWith(`/${displaySpec.specName}`))
+              const inFilteredDir = this.filteredDirectories.some(filterDir => (
+                filterDir.startsWith(`/${displaySpec.specName}`)
+              ))
               if (!inFilteredDir) {
                 continue
               }
@@ -271,7 +273,7 @@ limitations under the License.
             if (this.filteredDirectories.length > 0) {
               displaySpec.testFiles = matchingTestFiles
               displaySpec.testFiles = displaySpec.testFiles.filter(tf => (
-                this.filteredDirectories.some(filterDir =>  tf.testFile.startsWith(filterDir))
+                this.filteredDirectories.some(filterDir => tf.testFile.startsWith(filterDir))
               ))
             } else {
               displaySpec.testFiles = matchingTestFiles.slice(0, MAX_RESULTS_PER_SPEC)

--- a/templates/_head.html
+++ b/templates/_head.html
@@ -27,6 +27,10 @@ header h1 {
 header nav a {
     margin-right: 1em;
 }
+
+wpt-results {
+    margin-bottom: 5em;
+}
 </style>
 
 <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>


### PR DESCRIPTION
This PR fixes #27 and adds:

- The ability to visit a path like `/css/css-align-3`
- Links on all the spec names to these pages

The UI isn't super pretty, but it gets the job done. Any feedback welcome.

Check it out: https://directory-filtering-dot-wptdashboard.appspot.com/css/css-align-3