### PR TITLE
[WIP] Add test file pages with subtest results

### DIFF
--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -1,0 +1,182 @@
+<!--
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+
+<dom-module id="test-file-results">
+  <template>
+    <style>
+      :host {
+        display: block;
+        font-size: 16px;
+      }
+      h1 {
+        font-size: 1.5em;
+      }
+
+      /* TODO this is duplicated from wpt-results */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th.browser img {
+        width: 32px;
+        height: 32px;
+      }
+
+      tr.sub-test-results .OK, tr.sub-test-results .PASS {
+        background-color: rgb(90, 242, 113);
+      }
+      tr.sub-test-results .FAIL {
+        background-color: rgb(242, 90, 90);
+      }
+    </style>
+
+    <div>Test file results for:</div>
+    <h1>{{ testFile }}</h1>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Subtest</th>
+          <template is="dom-repeat" items="{{testRuns}}">
+            <th class="browser">
+              <div><img src="/static/{{item.browser_name}}_64x64.png" /></div>
+              <div>{{item.browser_name}} {{item.browser_version}}</div>
+              <div>{{item.os_name}} {{item.os_version}}</div>
+              <div>@{{item.revision}}</div>
+              <div>{{_dateFormat(item.created_at)}}</div>
+            </th>
+          </template>
+        </tr>
+      </thead>
+      <tbody>
+
+        <!-- for subTestname in subTestName (access by testRun.subtests[subTestName]) -->
+        <template is="dom-repeat" items="{{subtestNames}}" as="subtestName">
+          <tr class="sub-test-results">
+            <td>{{ subtestName }}</td>
+
+            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <td class$="[[ _subTestResultForTestRun(testRun, subtestName) ]]">
+                {{ _subTestResultForTestRun(testRun, subtestName) }}
+              </td>
+            </template>
+          </tr>
+        </template>
+
+      </tbody>
+    </table>
+
+
+
+  </template>
+
+  <script>
+    class TestFileResults extends window.Polymer.Element {
+      static get is () { return 'test-file-results' }
+
+      static get properties () {
+        return {
+          testRuns: {
+            type: Array
+          },
+          testFile: {
+            type: String
+          },
+          subtestNames: {
+            type: Array,
+            value: []
+            // value: ['Test file']
+          }
+        }
+      }
+
+      async connectedCallback () {
+        super.connectedCallback()
+        console.assert(this.testFile)
+        console.assert(this.testFile[0] === '/')
+        console.assert(this.testRuns)
+        console.assert(this.testRuns.length > 0)
+
+        const resultPerTestRun = await Promise.all(this.testRuns.map(testRun => (
+          this.loadResultFile(testRun, this.testFile)
+        )))
+
+        resultPerTestRun.forEach((resultData, i) => {
+          if (!resultData) return
+          const platformID = this._platformID(this.testRuns[i])
+          this.testRuns[i].subtests = {}
+          this.testRuns[i].subtests['Test file'] = { status: resultData.status }
+          this.subtestNames = this.subtestNames.concat(['Test file'])
+
+          for (let subTestResult of resultData.subtests) {
+            console.log('subTestResult', subTestResult)
+            this.testRuns[i].subtests[subTestResult.name] = subTestResult
+            if (!this.subtestNames.includes(subTestResult.name)) {
+              this.subtestNames = this.subtestNames.concat([subTestResult.name])
+            }
+          }
+        })
+      }
+
+      async loadResultFile (testRun, testFile) {
+        const url = this.resultsURL(testRun, testFile)
+        const response = await window.fetch(url)
+        if (response.status !== 200) {
+          console.log('Got non-200 status for url:', url)
+          return Promise.resolve(null)
+        }
+        return await response.json()
+      }
+
+      resultsURL (testRun, testFile) {
+        const resultsBase = 'https://storage.googleapis.com/wptdashboard.appspot.com/results'
+        const platformID = `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+        // FIXME for testing
+        // return `${resultsBase}288744c60d/chrome-61.0-linux-4.4.0-75-generic${testFile}`
+        return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
+
+      }
+
+     _subTestResultForTestRun (testRun, subtestName) {
+        if (!testRun) return null
+        if (!testRun.subtests) return null
+        if (!testRun.subtests[subtestName]) return null
+        if (testRun.subtests[subtestName].status === 'OK') return 'OK'
+        if (testRun.subtests[subtestName].status === 'PASS') return 'PASS'
+        if (testRun.subtests[subtestName].message) {
+          return `Failure message: ${testRun.subtests[subtestName].message}`
+        }
+        return testRun.subtests[subtestName].status
+      }
+
+      /* TODO these are duplicated from wpt-results */
+      _dateFormat (dateStr) {
+        return String(new Date(dateStr)).match(/^\w+ (\w+ \w+ \w+)/)[1]
+      }
+      _platformID (testRun) {
+        return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+      }
+      /* end duplication */
+
+    }
+
+    window.customElements.define(TestFileResults.is, TestFileResults)
+  </script>
+</dom-module>

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -17,6 +17,7 @@ limitations under the License.
 <link rel="import" href="/bower_components/polymer/polymer-element.html">
 <link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="/components/test-file-results.html">
 
 <dom-module id="wpt-results">
   <template>
@@ -56,63 +57,69 @@ limitations under the License.
       }
     </style>
 
-    <section class="search">
-      <input
-        value="{{query::input}}"
-        class="query"
-        placeholder="Search test files, like cors/allow-headers.htm">
-    </section>
+    <template is="dom-if" if="{{ testFileName.length }}">
+      <test-file-results style="margin-bottom: 5em;"
+        test-runs="[[testRuns]]"
+        test-file="[[testFileName]]">
+      </test-file-results>
+    </template>
 
-    <table>
-      <thead>
-        <tr>
-          <th>Spec</th>
-          <template is="dom-repeat" items="{{testRuns}}">
-            <th class="browser">
-              <div><img src="/static/{{item.browser_name}}_64x64.png" /></div>
-              <div>{{item.browser_name}} {{item.browser_version}}</div>
-              <div>{{item.os_name}} {{item.os_version}}</div>
-              <div>@{{item.revision}}</div>
-              <div>{{_dateFormat(item.created_at)}}</div>
-            </th>
-          </template>
-        </tr>
-      </thead>
-      <tbody>
+    <template is="dom-if" if="{{ !testFileName.length }}">
+      <section class="search">
+        <input
+          value="{{query::input}}"
+          class="query"
+          placeholder="Search test files, like cors/allow-headers.htm">
+      </section>
 
-        <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
-
-          <tr class="spec">
-            <td><b><a href="/{{specDir.specName}}">{{specDir.specName}}</a></b></td>
-
-            <template is="dom-repeat" items="{{specDir.results}}" as="result">
-              <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
+      <table>
+        <thead>
+          <tr>
+            <th>Spec</th>
+            <template is="dom-repeat" items="{{testRuns}}">
+              <th class="browser">
+                <div><img src="/static/{{item.browser_name}}_64x64.png" /></div>
+                <div>{{item.browser_name}} {{item.browser_version}}</div>
+                <div>{{item.os_name}} {{item.os_version}}</div>
+                <div>@{{item.revision}}</div>
+                <div>{{_dateFormat(item.created_at)}}</div>
+              </th>
             </template>
           </tr>
+        </thead>
+        <tbody>
 
-          <!-- TODO(jeffcarp): This nested sort isn't working -->
-          <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
-            <tr>
-              <!-- This is the only way I've found to get sub-lists to update -->
-              <td>{{ testFile.testFile }} <span style="display:none;">{{query}}</span></td>
+          <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
 
-              <template is="dom-repeat" items="{{testFile.results}}" as="result">
-                <td style="{{ _testResultStyle(result) }}">
-                  {{ _passingPercent(result) }}% ({{ result.passing }}/{{ result.total }})
-                  <span style="display:none;">{{query}}</span>
-                </td>
+            <tr class="spec">
+              <td><b><a href="/{{specDir.specName}}">{{specDir.specName}}</a></b></td>
+
+              <template is="dom-repeat" items="{{specDir.results}}" as="result">
+                <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
               </template>
             </tr>
-          </template>
 
-          <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
-            <!-- TODO(jeffcarp): add a button to show more results -->
-            <div>not all matching test files shown</div>
-          </template>
+            <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
+              <tr>
+                <td><a href="{{ testFile.testFile }}">{{ testFile.testFile }}</a></td>
 
-        </template>
-      </tbody>
-    </table>
+                <template is="dom-repeat" items="{{testFile.results}}" as="result">
+                  <td style="{{ _testResultStyle(result) }}">
+                    {{ _passingPercent(result) }}% ({{ result.passing }}/{{ result.total }})
+                  </td>
+                </template>
+              </tr>
+            </template>
+
+            <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
+              <!-- TODO(jeffcarp): add a button to show more results -->
+              <div>not all matching test files shown</div>
+            </template>
+
+          </template>
+        </tbody>
+      </table>
+    </template>
 
   </template>
 
@@ -139,13 +146,17 @@ limitations under the License.
             value: []
           },
           testRuns: {
-            type: Array
+            type: Array,
           },
           // If any directory names are present, displayedSpecDirs should be a
           // union of filteredDirectories, not an intersection.
           filteredDirectories: {
             type: Array,
             value: []
+          },
+          testFileName: {
+            type: String,
+            value: ''
           }
         }
       }
@@ -155,6 +166,12 @@ limitations under the License.
 
         if (window.location.pathname !== '/') {
           this.filteredDirectories.push(window.location.pathname)
+        }
+
+        // TODO is this an ok assumption?
+        if (window.location.pathname.endsWith('.html')) {
+          this.testFileName = window.location.pathname
+          return
         }
 
         const testFileResults = await Promise.all(this.testRuns.map(testRun => {


### PR DESCRIPTION
Resolves #41 

Branch deployed at https://test-file-pages-dot-wptdashboard.appspot.com

TODO
- [ ] Make 'page' component structure better (either move all directory-browsing-related stuff into its own component, or compile everything back into `wpt-results`
- [ ] Bug: currently duplicating 'Test file' subtest