### PR TITLE
Add test file pages that display subtest results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.pyc

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -30,7 +30,6 @@ limitations under the License.
         font-size: 1.5em;
       }
 
-      /* TODO this is duplicated from wpt-results */
       table {
         width: 100%;
         border-collapse: collapse;
@@ -60,7 +59,6 @@ limitations under the License.
         </tr>
       </thead>
       <tbody>
-        <!-- for subTestname in subTestName (access by testRun.subtests[subTestName]) -->
         <template is="dom-repeat" items="{{subtestNames}}" as="subtestName">
           <tr>
             <td class="sub-test-name">{{ subtestName }}</td>
@@ -75,7 +73,6 @@ limitations under the License.
 
       </tbody>
     </table>
-
   </template>
 
   <script>
@@ -104,9 +101,7 @@ limitations under the License.
         console.assert(this.testRuns)
         console.assert(this.testRuns.length > 0)
 
-        const resultPerTestRun = await Promise.all(this.testRuns.map(testRun => (
-          this.loadResultFile(testRun, this.testFile)
-        )))
+        const resultPerTestRun = await Promise.all(this.testRuns.map(tr => this.loadResultFile(tr)))
 
         resultPerTestRun.forEach((resultData, i) => {
           if (!resultData) {
@@ -130,8 +125,8 @@ limitations under the License.
         })
       }
 
-      async loadResultFile (testRun, testFile) {
-        const url = this.resultsURL(testRun, testFile)
+      async loadResultFile (testRun) {
+        const url = this.resultsURL(testRun, this.testFile)
         const response = await window.fetch(url)
         if (response.status !== 200) {
           console.error('Got non-200 status for url:', url)

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -1,0 +1,172 @@
+<!--
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="/components/test-run.html">
+
+<dom-module id="test-file-results">
+  <template>
+    <style>
+      :host {
+        display: block;
+        font-size: 16px;
+      }
+      h1 {
+        font-size: 1.5em;
+      }
+
+      /* TODO this is duplicated from wpt-results */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      td.sub-test-name {
+        font-family: monospace;
+        font-size: 0.9em;
+      }
+      td.result {
+        background-color: #eee;
+      }
+      td.result.OK, td.result.PASS {
+        background-color: rgb(90, 242, 113);
+      }
+      td.result.FAIL {
+        background-color: rgb(242, 90, 90);
+      }
+    </style>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Subtest</th>
+          <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+            <th><test-run test-run="[[testRun]]"></test-run></th>
+          </template>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- for subTestname in subTestName (access by testRun.subtests[subTestName]) -->
+        <template is="dom-repeat" items="{{subtestNames}}" as="subtestName">
+          <tr>
+            <td class="sub-test-name">{{ subtestName }}</td>
+
+            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <td class$="result [[ _subTestResultForTestRun(testRun, subtestName) ]]">
+                {{ _subTestResultForTestRun(testRun, subtestName) }}
+              </td>
+            </template>
+          </tr>
+        </template>
+
+      </tbody>
+    </table>
+
+  </template>
+
+  <script>
+    class TestFileResults extends window.Polymer.Element {
+      static get is () { return 'test-file-results' }
+
+      static get properties () {
+        return {
+          testRuns: {
+            type: Array
+          },
+          testFile: {
+            type: String
+          },
+          subtestNames: {
+            type: Array,
+            value: []
+          }
+        }
+      }
+
+      async connectedCallback () {
+        super.connectedCallback()
+        console.assert(this.testFile)
+        console.assert(this.testFile[0] === '/')
+        console.assert(this.testRuns)
+        console.assert(this.testRuns.length > 0)
+
+        const resultPerTestRun = await Promise.all(this.testRuns.map(testRun => (
+          this.loadResultFile(testRun, this.testFile)
+        )))
+
+        resultPerTestRun.forEach((resultData, i) => {
+          if (!resultData) {
+            this.testRuns[i].subtests = {}
+            this.testRuns[i].subtests['Test file'] = { status: '(results not found)' }
+            return
+          }
+          const platformID = this._platformID(this.testRuns[i])
+          this.testRuns[i].subtests = {}
+          this.testRuns[i].subtests['Test file'] = { status: resultData.status }
+
+          if (!this.subtestNames.includes('Test file')) {
+            this.subtestNames = this.subtestNames.concat(['Test file'])
+          }
+
+          for (let subTestResult of resultData.subtests) {
+            this.testRuns[i].subtests[subTestResult.name] = subTestResult
+            if (!this.subtestNames.includes(subTestResult.name)) {
+              this.subtestNames = this.subtestNames.concat([subTestResult.name])
+            }
+          }
+        })
+      }
+
+      async loadResultFile (testRun, testFile) {
+        const url = this.resultsURL(testRun, testFile)
+        const response = await window.fetch(url)
+        if (response.status !== 200) {
+          console.error('Got non-200 status for url:', url)
+          return Promise.resolve(null)
+        }
+        return await response.json()
+      }
+
+      resultsURL (testRun, testFile) {
+        const resultsBase = 'https://storage.googleapis.com/wptdashboard.appspot.com/results'
+        const platformID = `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+        return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
+
+      }
+
+     _subTestResultForTestRun (testRun, subtestName) {
+        if (!testRun) return null
+        if (!testRun.subtests) return null
+        if (!testRun.subtests[subtestName]) return null
+        if (testRun.subtests[subtestName].status === 'OK') return 'OK'
+        if (testRun.subtests[subtestName].status === 'PASS') return 'PASS'
+        if (testRun.subtests[subtestName].message) {
+          return `Failure message: ${testRun.subtests[subtestName].message}`
+        }
+        return testRun.subtests[subtestName].status
+      }
+
+      /* TODO this is duplicated from wpt-results */
+      _platformID (testRun) {
+        return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+      }
+
+    }
+
+    window.customElements.define(TestFileResults.is, TestFileResults)
+  </script>
+</dom-module>

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -59,13 +59,13 @@ limitations under the License.
         </tr>
       </thead>
       <tbody>
-        <template is="dom-repeat" items="{{subTestNames}}" as="subtestName">
+        <template is="dom-repeat" items="{{subtestNames}}" as="subtestName">
           <tr>
             <td class="sub-test-name">{{ subtestName }}</td>
 
             <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-              <td class$="result [[ _subTestResultForTestRun(testRun, subtestName) ]]">
-                {{ _subTestResultForTestRun(testRun, subtestName) }}
+              <td class$="result [[ _subtestResultForTestRun(testRun, subtestName) ]]">
+                {{ _subtestResultForTestRun(testRun, subtestName) }}
               </td>
             </template>
           </tr>
@@ -88,7 +88,7 @@ limitations under the License.
             type: String,
             observer: '_testFileChanged'
           },
-          subTestNames: {
+          subtestNames: {
             type: Array,
             value: []
           }
@@ -115,14 +115,14 @@ limitations under the License.
           this.testRuns[i].subtests = {}
           this.testRuns[i].subtests['Test file'] = { status: resultData.status }
 
-          if (!this.subTestNames.includes('Test file')) {
-            this.subTestNames = this.subTestNames.concat(['Test file'])
+          if (!this.subtestNames.includes('Test file')) {
+            this.subtestNames = this.subtestNames.concat(['Test file'])
           }
 
-          for (let subTestResult of resultData.subtests) {
-            this.testRuns[i].subtests[subTestResult.name] = subTestResult
-            if (!this.subTestNames.includes(subTestResult.name)) {
-              this.subTestNames = this.subTestNames.concat([subTestResult.name])
+          for (let subtestResult of resultData.subtests) {
+            this.testRuns[i].subtests[subtestResult.name] = subtestResult
+            if (!this.subtestNames.includes(subtestResult.name)) {
+              this.subtestNames = this.subtestNames.concat([subtestResult.name])
             }
           }
         })
@@ -139,7 +139,7 @@ limitations under the License.
       }
 
       _testFileChanged () {
-        this.subTestNames = []
+        this.subtestNames = []
         this.fetchTestFile()
       }
 
@@ -150,7 +150,7 @@ limitations under the License.
         return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
       }
 
-      _subTestResultForTestRun (testRun, subtestName) {
+      _subtestResultForTestRun (testRun, subtestName) {
         if (!testRun) return null
         if (!testRun.subtests) return null
         if (!testRun.subtests[subtestName]) return null

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -59,7 +59,7 @@ limitations under the License.
         </tr>
       </thead>
       <tbody>
-        <template is="dom-repeat" items="{{subtestNames}}" as="subtestName">
+        <template is="dom-repeat" items="{{subTestNames}}" as="subtestName">
           <tr>
             <td class="sub-test-name">{{ subtestName }}</td>
 
@@ -85,22 +85,25 @@ limitations under the License.
             type: Array
           },
           testFile: {
-            type: String
+            type: String,
+            observer: '_testFileChanged'
           },
-          subtestNames: {
+          subTestNames: {
             type: Array,
             value: []
           }
         }
       }
 
-      async connectedCallback () {
+      connectedCallback () {
         super.connectedCallback()
         console.assert(this.testFile)
         console.assert(this.testFile[0] === '/')
         console.assert(this.testRuns)
         console.assert(this.testRuns.length > 0)
+      }
 
+      async fetchTestFile () {
         const resultPerTestRun = await Promise.all(this.testRuns.map(tr => this.loadResultFile(tr)))
 
         resultPerTestRun.forEach((resultData, i) => {
@@ -112,14 +115,14 @@ limitations under the License.
           this.testRuns[i].subtests = {}
           this.testRuns[i].subtests['Test file'] = { status: resultData.status }
 
-          if (!this.subtestNames.includes('Test file')) {
-            this.subtestNames = this.subtestNames.concat(['Test file'])
+          if (!this.subTestNames.includes('Test file')) {
+            this.subTestNames = this.subTestNames.concat(['Test file'])
           }
 
           for (let subTestResult of resultData.subtests) {
             this.testRuns[i].subtests[subTestResult.name] = subTestResult
-            if (!this.subtestNames.includes(subTestResult.name)) {
-              this.subtestNames = this.subtestNames.concat([subTestResult.name])
+            if (!this.subTestNames.includes(subTestResult.name)) {
+              this.subTestNames = this.subTestNames.concat([subTestResult.name])
             }
           }
         })
@@ -133,6 +136,12 @@ limitations under the License.
           return Promise.resolve(null)
         }
         return response.json()
+      }
+
+      _testFileChanged () {
+        console.log('_testFileChanged')
+        this.subTestNames = []
+        this.fetchTestFile()
       }
 
       resultsURL (testRun, testFile) {

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -139,13 +139,13 @@ limitations under the License.
       }
 
       _testFileChanged () {
-        console.log('_testFileChanged')
         this.subTestNames = []
         this.fetchTestFile()
       }
 
       resultsURL (testRun, testFile) {
-        const resultsBase = 'https://storage.googleapis.com/wptdashboard.appspot.com/results'
+        // This is relying on the assumption that result files are under a directory named SHA[0:10]
+        const resultsBase = testRun.results_url.split('/' + testRun.revision)[0]
         const platformID = `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
         return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
       }

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -114,7 +114,6 @@ limitations under the License.
             this.testRuns[i].subtests['Test file'] = { status: '(results not found)' }
             return
           }
-          const platformID = this._platformID(this.testRuns[i])
           this.testRuns[i].subtests = {}
           this.testRuns[i].subtests['Test file'] = { status: resultData.status }
 
@@ -138,17 +137,16 @@ limitations under the License.
           console.error('Got non-200 status for url:', url)
           return Promise.resolve(null)
         }
-        return await response.json()
+        return response.json()
       }
 
       resultsURL (testRun, testFile) {
         const resultsBase = 'https://storage.googleapis.com/wptdashboard.appspot.com/results'
         const platformID = `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
         return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
-
       }
 
-     _subTestResultForTestRun (testRun, subtestName) {
+      _subTestResultForTestRun (testRun, subtestName) {
         if (!testRun) return null
         if (!testRun.subtests) return null
         if (!testRun.subtests[subtestName]) return null
@@ -159,12 +157,6 @@ limitations under the License.
         }
         return testRun.subtests[subtestName].status
       }
-
-      /* TODO this is duplicated from wpt-results */
-      _platformID (testRun) {
-        return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
-      }
-
     }
 
     window.customElements.define(TestFileResults.is, TestFileResults)

--- a/components/test-run.html
+++ b/components/test-run.html
@@ -1,0 +1,77 @@
+<!--
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<link rel="import" href="/bower_components/polymer/polymer-element.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+
+<!--
+`<test-run>` is a stateless component for displaying the details of a TestRun.
+
+The schema for the testRun property is as follows:
+{
+  "browser_name": "",
+  "browser_version": "",
+  "os_name": "",
+  "os_version": "",
+  "revision": "",     // the first 10 characters of the SHA
+  "created_at": "",   // the date the TestRun was uploaded
+}
+
+See models.go for more details.
+-->
+<dom-module id="test-run">
+  <template>
+    <style>
+      :host {
+        display: block;
+        font-size: 16px;
+      }
+      img {
+        width: 32px;
+        height: 32px;
+      }
+    </style>
+
+    <div>
+      <div><img src="/static/{{testRun.browser_name}}_64x64.png" /></div>
+      <div>{{testRun.browser_name}} {{testRun.browser_version}}</div>
+      <div>{{testRun.os_name}} {{testRun.os_version}}</div>
+      <div>@{{testRun.revision}}</div>
+      <div>{{dateFormat(testRun.created_at)}}</div>
+    </div>
+  </template>
+
+  <script>
+    class TestRun extends window.Polymer.Element {
+      static get is () { return 'test-run' }
+
+      static get properties () {
+        return {
+          testRun: {
+            type: Object
+          }
+        }
+      }
+
+      dateFormat (dateStr) {
+        return String(new Date(dateStr)).match(/^\w+ (\w+ \w+ \w+)/)[1]
+      }
+    }
+
+    window.customElements.define(TestRun.is, TestRun)
+  </script>
+</dom-module>

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -83,7 +83,7 @@ limitations under the License.
         <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
 
           <tr class="spec">
-            <td><b><a href="/{{specDir.specName}}">{{specDir.specName}}</a></b></td>
+            <td><b><a href="/{{specDir.specName}}" data-spec-name$="[[ specDir.specName ]]" on-click="_navigateSpec">{{specDir.specName}}</a></b></td>
 
             <template is="dom-repeat" items="{{specDir.results}}" as="result">
               <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
@@ -153,8 +153,17 @@ limitations under the License.
       async connectedCallback () {
         super.connectedCallback()
 
+        window.onpopstate = (event) => {
+          if (window.location.pathname === '/') {
+            this.filteredDirectories = []
+          } else {
+            this.filteredDirectories = [window.location.pathname]
+          }
+          this._refreshDisplayedSpecDirs()
+        }
+
         if (window.location.pathname !== '/') {
-          this.filteredDirectories.push(window.location.pathname)
+          this.filteredDirectories = [window.location.pathname]
         }
 
         const testFileResults = await Promise.all(this.testRuns.map(testRun => {
@@ -290,6 +299,16 @@ limitations under the License.
 
       _platformID (testRun) {
         return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+      }
+
+      // TODO: handle event where state is changed via back button
+      // TODO: make root navigation also use pushState (add breadcrumbs?)
+      _navigateSpec (event) {
+        event.preventDefault()
+        const specPath = '/' + event.target.dataset.specName
+        this.filteredDirectories = [specPath]
+        this._refreshDisplayedSpecDirs()
+        window.history.pushState({}, '', specPath)
       }
 
       /* Function for getting total numbers.

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -23,18 +23,26 @@ limitations under the License.
     <style>
       :host {
         display: block;
-        font-size: 16px;
+        font-size: 15px;
       }
       section.search {
         border-bottom: solid 1px #ccc;
         padding-bottom: 1em;
         margin-bottom: 1em;
       }
+      section.search .path {
+        margin-top: 1em;
+      }
       input.query {
         font-size: 16px;
         display: block;
         padding: 0.5em 0;
         width: 100%;
+      }
+      a {
+        text-decoration: none;
+        color: #0d5de6;
+        font-family: monospace;
       }
       table {
         width: 100%;
@@ -54,6 +62,9 @@ limitations under the License.
         padding: 0.2em 0.5em;
         border: solid 1px #ccc;
       }
+      .path-separator {
+        padding: 0 0.1em;
+      }
     </style>
 
     <section class="search">
@@ -61,7 +72,26 @@ limitations under the License.
         value="{{query::input}}"
         class="query"
         placeholder="Search test files, like cors/allow-headers.htm">
+      <div class="path">
+        <a href="/" on-click="_navigate">WPT</a>
+        <template is="dom-repeat" items="{{ _splitIntoLinkedParts(path) }}" as="part">
+          <span class="path-separator">/</span>
+          <a href="{{ part.path }}" on-click="_navigate">{{ part.name }}</a>
+        </template>
+      </div>
     </section>
+
+    <template is="dom-if" if="{{ pathIsATestFile }}">
+      <div>
+        Test file!!!!!!!
+      </div>
+    </template>
+
+    <template is="dom-if" if="{{ !pathIsATestFile }}">
+      <div>
+        Not a test file!!!!!!!
+      </div>
+    </template>
 
     <table>
       <thead>
@@ -90,24 +120,22 @@ limitations under the License.
             </template>
           </tr>
 
-          <!-- TODO(jeffcarp): This nested sort isn't working -->
           <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
             <tr>
-              <!-- This is the only way I've found to get sub-lists to update -->
-              <td>{{ testFile.testFile }} <span style="display:none;">{{query}}</span></td>
+              <td>
+                <template is="dom-repeat" items="{{ _splitIntoLinkedParts(testFile.testFile) }}" as="part"><span class="path-separator">/</span><a href="{{ part.path }}" on-click="_navigate">{{ part.name }}</a></template>
+              </td>
 
               <template is="dom-repeat" items="{{testFile.results}}" as="result">
                 <td style="{{ _testResultStyle(result) }}">
                   {{ _passingPercent(result) }}% ({{ result.passing }}/{{ result.total }})
-                  <span style="display:none;">{{query}}</span>
                 </td>
               </template>
             </tr>
           </template>
 
           <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
-            <!-- TODO(jeffcarp): add a button to show more results -->
-            <div>not all matching test files shown</div>
+            <a href="/{{ specDir.specName }}">See all files in the {{ specDir.specName }} spec</a>
           </template>
 
         </template>
@@ -141,11 +169,13 @@ limitations under the License.
           testRuns: {
             type: Array
           },
-          // If any directory names are present, displayedSpecDirs should be a
-          // union of filteredDirectories, not an intersection.
-          filteredDirectories: {
-            type: Array,
-            value: []
+          path: {
+            type: String,
+            value: window.location.pathname
+          },
+          pathIsATestFile: {
+            type: Boolean,
+            computed: '_computePathIsATestFile(path)'
           }
         }
       }
@@ -154,16 +184,8 @@ limitations under the License.
         super.connectedCallback()
 
         window.onpopstate = (event) => {
-          if (window.location.pathname === '/') {
-            this.filteredDirectories = []
-          } else {
-            this.filteredDirectories = [window.location.pathname]
-          }
+          this.path = window.location.pathname
           this._refreshDisplayedSpecDirs()
-        }
-
-        if (window.location.pathname !== '/') {
-          this.filteredDirectories = [window.location.pathname]
         }
 
         const testFileResults = await Promise.all(this.testRuns.map(testRun => {
@@ -197,6 +219,11 @@ limitations under the License.
         })
 
         this._refreshDisplayedSpecDirs()
+      }
+
+      _computePathIsATestFile (path) {
+        // TODO: Evaluate this assumption
+        return path.endsWith('.html')
       }
 
       _testFileSort (a, b) {
@@ -245,16 +272,14 @@ limitations under the License.
           displaySpecDir.specName = specDir.specName
           displaySpecDir.results = this.testRuns.map(testRun => specDir.results[testRun.results_url])
 
-          if (this.filteredDirectories.length > 0) {
-            const inFilteredDir = this.filteredDirectories.some(filterDir => (
-              filterDir.startsWith(`/${displaySpecDir.specName}`)
-            ))
+          if (this.path !== '/') {
+            const inFilteredDir = this.path.startsWith(`/${displaySpecDir.specName}`)
             if (!inFilteredDir) {
               continue
             }
           }
 
-          if (this.query.length < 3 && this.filteredDirectories.length === 0) {
+          if (this.query.length < 3 && this.path === '/') {
             displaySpecDir.testFiles = []
             displayedSpecDirs.push(displaySpecDir)
             continue
@@ -274,10 +299,10 @@ limitations under the License.
 
           let matchingTestFiles = allTestFiles.filter(matchesQuery)
           if (matchingTestFiles.length > 0) {
-            if (this.filteredDirectories.length > 0) {
+            if (this.path !== '/') {
               displaySpecDir.testFiles = matchingTestFiles
               displaySpecDir.testFiles = displaySpecDir.testFiles.filter(tf => (
-                this.filteredDirectories.some(filterDir => tf.testFile.startsWith(filterDir))
+                tf.testFile.startsWith(this.path)
               ))
             } else {
               displaySpecDir.testFiles = matchingTestFiles.slice(0, MAX_RESULTS_PER_SPEC_DIR)
@@ -301,14 +326,42 @@ limitations under the License.
         return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
       }
 
+      _navigate (event) {
+        event.preventDefault()
+        const path = event.target.pathname
+        if (path === this.path) {
+          return
+        }
+        this.path = path
+        this.query = ''
+        this._refreshDisplayedSpecDirs()
+        window.history.pushState({}, '', path)
+      }
+
       // TODO: handle event where state is changed via back button
       // TODO: make root navigation also use pushState (add breadcrumbs?)
       _navigateSpec (event) {
         event.preventDefault()
         const specPath = '/' + event.target.dataset.specName
-        this.filteredDirectories = [specPath]
+        if (specPath === this.path) {
+          return
+        }
+        this.path = specPath
+        this.query = ''
         this._refreshDisplayedSpecDirs()
         window.history.pushState({}, '', specPath)
+      }
+
+      _splitIntoLinkedParts (path) {
+        const parts = path.split('/').slice(1)
+        let pathSoFar = ''
+        return parts.map(part => {
+          pathSoFar += '/' + part
+          return {
+            name: part,
+            path: pathSoFar
+          }
+        })
       }
 
       /* Function for getting total numbers.

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -104,7 +104,7 @@ limitations under the License.
           <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
 
             <tr class="spec">
-              <td><b><a href="/{{specDir.specName}}" data-spec-name$="[[ specDir.specName ]]" on-click="_navigateSpec">{{specDir.specName}}</a></b></td>
+              <td><b><a href="/{{specDir.specName}}" on-click="_navigate">{{specDir.specName}}</a></b></td>
 
               <template is="dom-repeat" items="{{specDir.results}}" as="result">
                 <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
@@ -214,7 +214,6 @@ limitations under the License.
       }
 
       _computePathIsATestFile (path) {
-        // TODO: Evaluate this assumption
         return path.endsWith('.html') || path.endsWith('.htm')
       }
 
@@ -323,20 +322,6 @@ limitations under the License.
         this.query = ''
         this._refreshDisplayedSpecDirs()
         window.history.pushState({}, '', path)
-      }
-
-      // TODO: handle event where state is changed via back button
-      // TODO: make root navigation also use pushState (add breadcrumbs?)
-      _navigateSpec (event) {
-        event.preventDefault()
-        const specPath = '/' + event.target.dataset.specName
-        if (specPath === this.path) {
-          return
-        }
-        this.path = specPath
-        this.query = ''
-        this._refreshDisplayedSpecDirs()
-        window.history.pushState({}, '', specPath)
       }
 
       _splitIntoLinkedParts (path) {

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -17,6 +17,8 @@ limitations under the License.
 <link rel="import" href="/bower_components/polymer/polymer-element.html">
 <link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="/components/test-file-results.html">
+<link rel="import" href="/components/test-run.html">
 
 <dom-module id="wpt-results">
   <template>
@@ -44,13 +46,12 @@ limitations under the License.
         color: #0d5de6;
         font-family: monospace;
       }
+      a:hover {
+        color: #226ff3;
+      }
       table {
         width: 100%;
         border-collapse: collapse;
-      }
-      th.browser img {
-        width: 32px;
-        height: 32px;
       }
       tr.spec {
         background-color: #eee;
@@ -82,65 +83,56 @@ limitations under the License.
     </section>
 
     <template is="dom-if" if="{{ pathIsATestFile }}">
-      <div>
-        Test file!!!!!!!
-      </div>
+      <test-file-results
+        test-runs="[[testRuns]]"
+        test-file="[[path]]">
+      </test-file-results>
     </template>
 
     <template is="dom-if" if="{{ !pathIsATestFile }}">
-      <div>
-        Not a test file!!!!!!!
-      </div>
-    </template>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Spec</th>
-          <template is="dom-repeat" items="{{testRuns}}">
-            <th class="browser">
-              <div><img src="/static/{{item.browser_name}}_64x64.png" /></div>
-              <div>{{item.browser_name}} {{item.browser_version}}</div>
-              <div>{{item.os_name}} {{item.os_version}}</div>
-              <div>@{{item.revision}}</div>
-              <div>{{_dateFormat(item.created_at)}}</div>
-            </th>
-          </template>
-        </tr>
-      </thead>
-      <tbody>
-
-        <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
-
-          <tr class="spec">
-            <td><b><a href="/{{specDir.specName}}" data-spec-name$="[[ specDir.specName ]]" on-click="_navigateSpec">{{specDir.specName}}</a></b></td>
-
-            <template is="dom-repeat" items="{{specDir.results}}" as="result">
-              <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
+      <table>
+        <thead>
+          <tr>
+            <th>Spec</th>
+            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <th><test-run test-run="[[testRun]]"></test-run></th>
             </template>
           </tr>
+        </thead>
+        <tbody>
 
-          <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
-            <tr>
-              <td>
-                <template is="dom-repeat" items="{{ _splitIntoLinkedParts(testFile.testFile) }}" as="part"><span class="path-separator">/</span><a href="{{ part.path }}" on-click="_navigate">{{ part.name }}</a></template>
-              </td>
+          <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
 
-              <template is="dom-repeat" items="{{testFile.results}}" as="result">
-                <td style="{{ _testResultStyle(result) }}">
-                  {{ _passingPercent(result) }}% ({{ result.passing }}/{{ result.total }})
-                </td>
+            <tr class="spec">
+              <td><b><a href="/{{specDir.specName}}" data-spec-name$="[[ specDir.specName ]]" on-click="_navigateSpec">{{specDir.specName}}</a></b></td>
+
+              <template is="dom-repeat" items="{{specDir.results}}" as="result">
+                <td>{{ _passingPercent(result) }}% ({{ result.passing }} / {{ result.total }})</td>
               </template>
             </tr>
-          </template>
 
-          <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
-            <a href="/{{ specDir.specName }}">See all files in the {{ specDir.specName }} spec</a>
-          </template>
+            <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
+              <tr>
+                <td>
+                  <template is="dom-repeat" items="{{ _splitIntoLinkedParts(testFile.testFile) }}" as="part"><span class="path-separator">/</span><a href="{{ part.path }}" on-click="_navigate">{{ part.name }}</a></template>
+                </td>
 
-        </template>
-      </tbody>
-    </table>
+                <template is="dom-repeat" items="{{testFile.results}}" as="result">
+                  <td style="{{ _testResultStyle(result) }}">
+                    {{ _passingPercent(result) }}% ({{ result.passing }}/{{ result.total }})
+                  </td>
+                </template>
+              </tr>
+            </template>
+
+            <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
+              <a href="/{{ specDir.specName }}">See all files in the {{ specDir.specName }} spec</a>
+            </template>
+
+          </template>
+        </tbody>
+      </table>
+    </template>
 
   </template>
 
@@ -223,7 +215,7 @@ limitations under the License.
 
       _computePathIsATestFile (path) {
         // TODO: Evaluate this assumption
-        return path.endsWith('.html')
+        return path.endsWith('.html') || path.endsWith('.htm')
       }
 
       _testFileSort (a, b) {
@@ -317,11 +309,6 @@ limitations under the License.
         this.set('displayedSpecDirs', displayedSpecDirs)
       }
 
-      _passingPercent (item) {
-        if (!item || isNaN(item.passing) || isNaN(item.total)) return ''
-        return parseFloat((item.passing / item.total) * 100).toFixed(1)
-      }
-
       _platformID (testRun) {
         return `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
       }
@@ -364,6 +351,26 @@ limitations under the License.
         })
       }
 
+      _testResultStyle (result) {
+        if (!result) return ''
+
+        // Need saturation between 65-100, reversed (range 35)
+        const passRate = result.passing / result.total
+        if (passRate === 1) {
+          // Green
+          return 'background-color: hsl(129, 85%, 65%)'
+        } else {
+          const luminance = 65 + passRate * 20
+          // Some shade of red
+          return `background-color: hsl(0, 85%, ${luminance}%)`
+        }
+      }
+
+      _passingPercent (item) {
+        if (!item || isNaN(item.passing) || isNaN(item.total)) return ''
+        return parseFloat((item.passing / item.total) * 100).toFixed(1)
+      }
+
       /* Function for getting total numbers.
        * Intentionally not exposed in UI.
        * To generate, open your console and run:
@@ -394,25 +401,6 @@ limitations under the License.
         })))
 
         console.log('JSON version:', JSON.stringify(totals))
-      }
-
-      _dateFormat (dateStr) {
-        return String(new Date(dateStr)).match(/^\w+ (\w+ \w+ \w+)/)[1]
-      }
-
-      _testResultStyle (result) {
-        if (!result) return ''
-
-        // Need saturation between 65-100, reversed (range 35)
-        const passRate = result.passing / result.total
-        if (passRate === 1) {
-          // Green
-          return 'background-color: hsl(129, 85%, 65%)'
-        } else {
-          const luminance = 65 + passRate * 20
-          // Some shade of red
-          return `background-color: hsl(0, 85%, ${luminance}%)`
-        }
       }
     }
 

--- a/models.go
+++ b/models.go
@@ -25,7 +25,7 @@ type TestRun struct {
     OSName          string          `json:"os_name"`
     OSVersion       string          `json:"os_version"`
 
-    // The full SHA1 of the tested WPT revision
+    // The first 10 characters of the SHA1 of the tested WPT revision
     Revision        string          `json:"revision"`
 
     // Results URL

--- a/templates/_head.html
+++ b/templates/_head.html
@@ -16,6 +16,7 @@ body {
 }
 a {
     text-decoration: none;
+    color: #0d5de6;
 }
 header {
     padding: 0.5em 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,9 +4,11 @@
 <body>
 
 <div id="content">
+    <!-- TODO: move <header> to shared file -->
     <header>
         <h1><a href="/">web-platform-tests dashboard</a></h1>
         <nav>
+            <!-- TODO: handle onclick with wpt-results.navigate if available -->
             <a href="/">Root</a>
             <a href="/about">About</a>
         </nav>


### PR DESCRIPTION
Resolves #41 

This PR:
- Adds pages for individual test results: [example](https://pushstate-dot-wptdashboard.appspot.com/custom-elements/parser/parser-uses-constructed-element.html)
- Adds directory links that use [pushState](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries) for much quicker directory navigation (no page reload)
- Removes the underlying plumbing to select multiple directories (to simplify things for now)
- Adds directory navigation breadcrumb links to the top under search

Additional smaller changes:
- Add the `<test-run>` static component for UI simplification
- Changes all link colors to blue
- Changes font of directory names and subtest names to `monospace`

TODO:
- [x] Bug: the test file result set may not be changing across navigations

This branch is deployed at: https://pushstate-dot-wptdashboard.appspot.com/