### PR TITLE
Add browser list, validation tests, and use it in TestHandler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
-language: node_js
-node_js:
-  - "node"
+matrix:
+  include:
+    - language: node_js
+      node_js:
+        - "node"
+
+    - language: python
+      python: 2.7
+      script:
+        - python -m unittest discover -p "*_test.py"

--- a/browsers.json
+++ b/browsers.json
@@ -1,0 +1,35 @@
+{
+    "chrome-61.0-linux": {
+        "initially_loaded": true,
+        "currently_run": true,
+        "browser_name": "chrome",
+        "browser_version": "61.0",
+        "os_name": "linux",
+        "os_version": "*"
+    },
+    "chrome-60.0-linux": {
+        "initially_loaded": false,
+        "currently_run": false,
+        "browser_name": "chrome",
+        "browser_version": "60.0",
+        "os_name": "linux",
+        "os_version": "*"
+    },
+    "firefox-56.0-linux": {
+        "initially_loaded": true,
+        "currently_run": true,
+        "browser_name": "firefox",
+        "browser_version": "56.0",
+        "os_name": "linux",
+        "os_version": "*"
+    },
+    "edge-15-windows-10-sauce": {
+        "initially_loaded": true,
+        "currently_run": true,
+        "browser_name": "edge",
+        "browser_version": "15",
+        "os_name": "windows",
+        "os_version": "10",
+        "sauce": true
+    }
+}

--- a/models.go
+++ b/models.go
@@ -33,3 +33,13 @@ type TestRun struct {
 
     CreatedAt       time.Time       `json:"created_at"`
 }
+
+
+type Browser struct {
+    InitiallyLoaded bool            `json:"initially_loaded"`
+    BrowserName     string          `json:"browser_name"`
+    BrowserVersion  string          `json:"browser_version"`
+    OSName          string          `json:"os_name"`
+    OSVersion       string          `json:"os_version"`
+    Sauce           bool            `json:"sauce"`
+}

--- a/run/browsers_test.py
+++ b/run/browsers_test.py
@@ -1,7 +1,21 @@
-import unittest
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import os
 import re
+import unittest
 
 
 VALID_PLATFORM_ID_REGEX = r"^[a-z0-9\-\.]+$"
@@ -16,11 +30,11 @@ REQUIRED_PLATFORM_FIELDS = {
 
 class TestBrowsers(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(TestBrowsers, self).__init__(*args, **kwargs)
+    @classmethod
+    def setUpClass(cls):
         filepath = os.path.join(os.path.dirname(__file__), os.pardir, 'browsers.json')
         with open(filepath) as f:
-            self.browsers = json.load(f)
+            cls.browsers = json.load(f)
 
     def test_all_platforms_have_only_valid_characters(self):
         for platform_id, platform_info in self.browsers.iteritems():
@@ -33,7 +47,7 @@ class TestBrowsers(unittest.TestCase):
                 self.assertTrue(key in platform_info.keys(),
                     'Required field missing: %s (platform %s)' % (key, platform_id))
 
-                if REQUIRED_PLATFORM_FIELDS[key] != None:
+                if REQUIRED_PLATFORM_FIELDS[key] is not None:
                     self.assertTrue(platform_info[key] in REQUIRED_PLATFORM_FIELDS[key],
                         'Field has invalid value: %s (platform %s)' % (key, platform_id))
 

--- a/run/browsers_test.py
+++ b/run/browsers_test.py
@@ -1,0 +1,52 @@
+import unittest
+import json
+import os
+import re
+
+
+VALID_PLATFORM_ID_REGEX = r"^[a-z0-9\-\.]+$"
+REQUIRED_PLATFORM_FIELDS = {
+    'currently_run': (True, False),
+    'initially_loaded': (True, False),
+    'browser_name': ('chrome', 'firefox', 'edge'),
+    'browser_version': None,
+    'os_name': ('linux', 'windows'),
+    'os_version': None,
+}
+
+class TestBrowsers(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(TestBrowsers, self).__init__(*args, **kwargs)
+        filepath = os.path.join(os.path.dirname(__file__), os.pardir, 'browsers.json')
+        with open(filepath) as f:
+            self.browsers = json.load(f)
+
+    def test_all_platforms_have_only_valid_characters(self):
+        for platform_id, platform_info in self.browsers.iteritems():
+            self.assertTrue(re.match(VALID_PLATFORM_ID_REGEX, platform_id),
+                'platform_id with invalid characters: %s' % platform_id)
+
+    def test_all_browsers_have_required_fields(self):
+        for platform_id, platform_info in self.browsers.iteritems():
+            for key, valid_values in REQUIRED_PLATFORM_FIELDS.iteritems():
+                self.assertTrue(key in platform_info.keys(),
+                    'Required field missing: %s (platform %s)' % (key, platform_id))
+
+                if REQUIRED_PLATFORM_FIELDS[key] != None:
+                    self.assertTrue(platform_info[key] in REQUIRED_PLATFORM_FIELDS[key],
+                        'Field has invalid value: %s (platform %s)' % (key, platform_id))
+
+    def test_no_two_browser_configs_are_equal(self):
+        for first_platform_id, first_platform in self.browsers.iteritems():
+            identical_platforms = [
+                second_platform for second_platform_id, second_platform
+                in self.browsers.iteritems()
+                if second_platform == first_platform
+            ]
+            self.assertEqual(len(identical_platforms), 1,
+                'Duplicate platforms detected: %s' % identical_platforms)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test_handler.go
+++ b/test_handler.go
@@ -17,18 +17,46 @@ package wptdashboard
 import (
     "encoding/json"
     "net/http"
+    "io/ioutil"
+    "sort"
 
     "appengine"
     "appengine/datastore"
 )
 
+// This handler is responsible for all pages that display test results.
+// It fetches the latest TestRun for each browser then renders the HTML
+// page with the TestRuns encoded as JSON. The Polymer app picks those up
+// and loads the summary files based on each entity's TestRun.ResultsURL.
+//
+// The browsers initially displayed to the user are defined in browsers.json.
+// The JSON property "initially_loaded" is what controls this.
 func testHandler(w http.ResponseWriter, r *http.Request) {
     ctx := appengine.NewContext(r)
+    var bytes []byte
+    var err error
+    var browsers map[string]Browser
+
+    if bytes, err = ioutil.ReadFile("browsers.json"); err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+
+    if err = json.Unmarshal(bytes, &browsers); err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
 
     var testRuns []TestRun
     baseQuery := datastore.NewQuery("TestRun").Order("-CreatedAt").Limit(1)
-    // TODO(jeffcarp): get these from browsers.json once it lands on master
-    browserNames := []string{"chrome", "edge", "firefox"}
+    var browserNames []string
+
+    for _, browser := range browsers {
+        if browser.InitiallyLoaded {
+            browserNames = append(browserNames, browser.BrowserName)
+        }
+    }
+    sort.Strings(browserNames)
 
     for _, browserName := range browserNames {
         var testRunResults []TestRun
@@ -43,10 +71,12 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
     testRunsBytes, err := json.Marshal(testRuns)
     if err != nil {
         http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
     }
     testRunsJSON := string(testRunsBytes)
 
     if err := templates.ExecuteTemplate(w, "index.html", testRunsJSON); err != nil {
         http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
     }
 }


### PR DESCRIPTION
Resolves #47

I decided to split this change out of #17 since it's ready to land and useful.

This PR:
- Adds `browsers.json`, a file listing all platforms we intend to test and display
- Splits Travis into Node and Python builds
- Adds a Python unit test that validates the values of `browsers.json`
- Changes the main `testHandler` to read `browsers.json` and display only those marked as  "initially_loaded" 