### PR TITLE
Fix Google Analytics page tracking

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -322,6 +322,11 @@ limitations under the License.
         this.query = ''
         this._refreshDisplayedSpecDirs()
         window.history.pushState({}, '', path)
+
+        // Send Google Analytics pageview event
+        if ('ga' in window) {
+          window.ga('send', 'pageview', path)
+        }
       }
 
       _splitIntoLinkedParts (path) {


### PR DESCRIPTION
Now that all results pages act like a SPA, page view events are
no longer being sent to Google Analytics. This fixes that by
manually sending the event.