### PR TITLE
Support Safari 10 and Edge 15 by fixing infinite import loop problem

### DIFF
--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="/bower_components/polymer/polymer-element.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
-<link rel="import" href="/components/test-run.html">
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="test-run.html">
 
 <dom-module id="test-file-results">
   <template>

--- a/components/test-run.html
+++ b/components/test-run.html
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="/bower_components/polymer/polymer-element.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 
 <!--
 `<test-run>` is a stateless component for displaying the details of a TestRun.

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-<link rel="import" href="/bower_components/polymer/polymer-element.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-if.html">
-<link rel="import" href="/bower_components/polymer/lib/elements/dom-repeat.html">
-<link rel="import" href="/components/test-file-results.html">
-<link rel="import" href="/components/test-run.html">
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="test-file-results.html">
+<link rel="import" href="test-run.html">
 
 <dom-module id="wpt-results">
   <template>


### PR DESCRIPTION
Fixes #19 

I was vexed for a while trying to support Safari since it would enter an infinite loop loading all the HTML imports over and over again. After a bunch of searching it looks like the problem was that we were using absolute paths:

```html
<link rel="import" href="/bower_components/polymer/polymer-element.html">
```

instead of relative paths:

```html
<link rel="import" href="../bower_components/polymer/polymer-element.html">
```

So that fixes the problem. I've verified that this works in the following browsers:

- [x] Chrome 59
- [x] Firefox 54
- [x] Safari 10
- [x] Edge 15 (Edge 14 ran into import issues that I don't have time to debug right now)

Also cc @gsnedders FYI