### PR TITLE
Fix test file results URL building

### DIFF
--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -146,7 +146,7 @@ limitations under the License.
       resultsURL (testRun, testFile) {
         // This is relying on the assumption that result files are under a directory named SHA[0:10]
         const resultsBase = testRun.results_url.split('/' + testRun.revision)[0]
-        const platformID = `${testRun.browser_name}-${testRun.browser_version}-${testRun.os_name}-${testRun.os_version}`
+        const platformID = testRun.results_url.split('/').pop().replace('-summary.json.gz', '')
         return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
       }
 

--- a/components/test-file-results.html
+++ b/components/test-file-results.html
@@ -144,9 +144,14 @@ limitations under the License.
       }
 
       resultsURL (testRun, testFile) {
-        // This is relying on the assumption that result files are under a directory named SHA[0:10]
+        // This is relying on the assumption that result files are under a directory named SHA[0:10].
         const resultsBase = testRun.results_url.split('/' + testRun.revision)[0]
+        // This is currently a hack to extract the platform ID from the summary URL.
+        // A platform ID is any valid key from browsers.json.
         const platformID = testRun.results_url.split('/').pop().replace('-summary.json.gz', '')
+        // Test file results are currently stored as JSON files with the following scheme:
+        // {GS bucket}/{WPT SHA[0:10]}/{platform ID}/{test file path}
+
         return `${resultsBase}/${testRun.revision}/${platformID}${testFile}`
       }
 


### PR DESCRIPTION
Fixes #65 

Since I removed the requirement that platform IDs have a regular structure in #47, test file results now don't show up on individual test pages because they were relying on that structure. 

This is a quick fix. We should have a better solution long-term, like storing the platform ID inside the TestRun.

Compare:
- https://wptdashboard.appspot.com/domparsing/DOMParser-parseFromString-html.html
- https://fix-test-file-results-url-dot-wptdashboard.appspot.com/domparsing/DOMParser-parseFromString-html.html