### PR TITLE
Only show immediate children in directories

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -222,21 +222,21 @@ limitations under the License.
       }
 
       _refreshDisplayedNodes () {
-        /* Recomputes the list of displayed spec directories and their child test results. */
-        const displayedNodeDict = {}
+        /* Recomputes the list of displayed directories and test files. */
+        const displayedNodeMap = new Map()
         const currentPathParts = this._splitIntoLinkedParts(this.path)
 
         const updateResults = (testFileName, dirPath, isDir) => {
-          if (!(dirPath in displayedNodeDict)) {
-            displayedNodeDict[dirPath] = {isDir: isDir, results: {}}
+          if (!displayedNodeMap.has(dirPath)) {
+            displayedNodeMap.set(dirPath, {isDir: isDir, results: {}})
           }
           let results = this.testFiles[testFileName]
           Object.keys(results).forEach(resultURL => {
-            if (!(resultURL in displayedNodeDict[dirPath].results)) {
-              displayedNodeDict[dirPath].results[resultURL] = {passing: 0, total: 0}
+            if (!(resultURL in displayedNodeMap.get(dirPath).results)) {
+              displayedNodeMap.get(dirPath).results[resultURL] = {passing: 0, total: 0}
             }
-            displayedNodeDict[dirPath].results[resultURL].passing += results[resultURL][0]
-            displayedNodeDict[dirPath].results[resultURL].total += results[resultURL][1]
+            displayedNodeMap.get(dirPath).results[resultURL].passing += results[resultURL][0]
+            displayedNodeMap.get(dirPath).results[resultURL].total += results[resultURL][1]
           })
         }
 
@@ -254,18 +254,18 @@ limitations under the License.
 
           let parts = this._splitIntoLinkedParts(testFileName)
 
-          // Catch any top-level directories
+          // If at the top-level, add all directories
           if (this.path === '/' && parts.length === 2) {
             let dirParts = [parts[0]]
             let dirPath = dirParts[dirParts.length - 1].path
             updateResults(testFileName, dirPath, true)
 
-          // Catch any test files in child directories
+          // Add test files in current directory
           } else if (parts.length === currentPathParts.length + 1) {
             let path = parts[parts.length - 1].path
             updateResults(testFileName, path, false)
 
-          // Catch all subdirectories
+          // Add subdirectories in current directory
           } else if (parts.length > currentPathParts.length + 1) {
             let dirParts
             if (this.path === '/') {
@@ -277,8 +277,9 @@ limitations under the License.
             updateResults(testFileName, dirPath, true)
           }
         })
-        let displayedNodes = Object.keys(displayedNodeDict).map(key => (
-          {path: key, isDir: displayedNodeDict[key].isDir, results: displayedNodeDict[key].results}
+
+        let displayedNodes = Array.from(displayedNodeMap.keys()).map(key => (
+          {path: key, isDir: displayedNodeMap.get(key).isDir, results: displayedNodeMap.get(key).results}
         ))
         displayedNodes.sort(this._nodeSort)
         this.displayedNodes = displayedNodes

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -300,7 +300,7 @@ limitations under the License.
         const currentPathParts = this._splitIntoLinkedParts(this.path)
 
         const updateResults = (testFileName, dirPath, isDir) => {
-          if (!(testFileName in displayedNodeDict)) {
+          if (!(dirPath in displayedNodeDict)) {
             displayedNodeDict[dirPath] = {isDir: isDir, results: {}}
           }
           let results = this.testFiles[testFileName]
@@ -330,7 +330,7 @@ limitations under the License.
             let path = parts[parts.length - 1].path
             updateResults(testFileName, path, false)
 
-          // Catch directories
+          // Catch all subdirectories
           } else if (parts.length > currentPathParts.length + 1) {
             let dirParts
             if (this.path === '/') {
@@ -339,29 +339,10 @@ limitations under the License.
               dirParts = parts.slice(0, currentPathParts.length + 1)
             }
             let dirPath = dirParts[dirParts.length - 1].path
+            if (testFileName.includes('building-paths')) console.log(testFileName, dirParts, dirPath)
             updateResults(testFileName, dirPath, true)
           }
 
-            /*
-            // Catch any test files in child directories
-            } else if (parts.length === currentPathParts.length + 1) {
-              //let dirParts = parts.slice(0, currentPathParts.length + 1)
-              // let dirPath = dirParts[dirParts.length - 1].path
-              // updateResults(testFileName, dirPath, false)
-
-            // Catch directories further down the tree
-            } else if (parts.length > currentPathParts.length + 1) {
-              let dirParts
-              if (this.path === '/') {
-                dirParts = [parts[0]]
-              } else {
-                dirParts = parts.slice(0, currentPathParts.length + 1)
-              }
-              let dirPath = dirParts[dirParts.length - 1].path
-              // displayedNodeDict[dirPath] = {isDir: true, results: {}}
-              updateResults(testFileName, dirPath, true)
-            }
-            */
         })
         let displayedNodes = Object.keys(displayedNodeDict).map(key => (
           {path: key, isDir: displayedNodeDict[key].isDir, results: displayedNodeDict[key].results}

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -47,6 +47,7 @@ limitations under the License.
         font-family: monospace;
       }
       a:hover {
+        cursor: pointer;
         color: #226ff3;
       }
       table {
@@ -223,8 +224,6 @@ limitations under the License.
       _refreshDisplayedNodes () {
         /* Recomputes the list of displayed spec directories and their child test results. */
         const displayedNodeDict = {}
-        // FIXME: add back search result matching
-        // const matchesQueryng = (name) => name.toLowerCase().includes(this.query.toLowerCase())
         const currentPathParts = this._splitIntoLinkedParts(this.path)
 
         const updateResults = (testFileName, dirPath, isDir) => {
@@ -242,9 +241,17 @@ limitations under the License.
         }
 
         Object.keys(this.testFiles).forEach(testFileName => {
-          if (!testFileName.startsWith(this.path)) {
+          if (this.path !== '/' && !testFileName.startsWith(this.path + '/')) {
             return
           }
+
+          if (this.query.length > 0) {
+            const matchesQuery = testFileName.toLowerCase().includes(this.query.toLowerCase())
+            if (!matchesQuery) {
+              return
+            }
+          }
+
           let parts = this._splitIntoLinkedParts(testFileName)
 
           // Catch any top-level directories
@@ -267,7 +274,6 @@ limitations under the License.
               dirParts = parts.slice(0, currentPathParts.length + 1)
             }
             let dirPath = dirParts[dirParts.length - 1].path
-            if (testFileName.includes('building-paths')) console.log(testFileName, dirParts, dirPath)
             updateResults(testFileName, dirPath, true)
           }
         })
@@ -289,7 +295,6 @@ limitations under the License.
           return
         }
         this.path = path
-        this.query = ''
         this._refreshDisplayedNodes()
         window.history.pushState({}, '', path)
 
@@ -317,6 +322,12 @@ limitations under the License.
         if (!(testRun.results_url in node.results)) return
         const result = node.results[testRun.results_url]
 
+        if (this.path === '/') {
+          // Do not add color to top-level directories
+          return 'background-color: #eee'
+        }
+
+
         // Need saturation between 65-100, reversed (range 35)
         const passRate = result.passing / result.total
         if (passRate === 1) {
@@ -337,6 +348,11 @@ limitations under the License.
         if (testRun.results_url in node.results) {
           return node.results[testRun.results_url][property]
         }
+      }
+
+      _clearSearch () {
+        this.query = ''
+        this._refreshDisplayedNodes()
       }
 
       /* Function for getting total numbers.

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -113,7 +113,11 @@ limitations under the License.
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-                <td style="{{ _testResultStyle(node, testRun) }}">{{ _passingForNode(node, testRun) }} / {{ _totalForNode(node, testRun) }}</td>
+                <td style="{{ _testResultStyle(node, testRun) }}">
+                  {{ _resultForNode(node, testRun, 'passing') }}
+                  /
+                  {{ _resultForNode(node, testRun, 'total') }}
+                </td>
               </template>
 
             </tr>
@@ -135,17 +139,6 @@ limitations under the License.
             type: String,
             value: '',
             observer: '_queryChanged'
-          },
-          // An object where the key is a top-level directory in WPT (top-level
-          // directories are spec names) and the value is an object containing
-          // all test files in the spec directory.
-          specDirs: {
-            type: Object,
-            value: {}
-          },
-          displayedSpecDirs: {
-            type: Array,
-            value: []
           },
           testRuns: {
             type: Array
@@ -174,7 +167,7 @@ limitations under the License.
 
         window.onpopstate = (event) => {
           this.path = window.location.pathname
-          this._refreshDisplayedSpecDirs()
+          this._refreshDisplayedNodes()
         }
 
         const testFileResults = await Promise.all(this.testRuns.map(testRun => {
@@ -182,10 +175,7 @@ limitations under the License.
         }))
 
         testFileResults.forEach(result => {
-          const testFiles = result.testFiles
           const resultsURL = result.resultsURL
-
-          // EXPERIMENTAL
 
           Object.keys(result.testFiles).forEach(testFileName => {
             if (!(testFileName in this.testFiles)) {
@@ -193,48 +183,13 @@ limitations under the License.
             }
             this.testFiles[testFileName][resultsURL] = result.testFiles[testFileName]
           })
-
-          // END EXPERIMENTAL
-
-          Object.keys(result.testFiles).forEach(testFileName => {
-            const specName = this._specFromTestPath(testFileName)
-
-            if (!(specName in this.specDirs)) {
-              this.specDirs[specName] = {results: {}, specName: specName, testFiles: {}}
-            }
-            if (!(resultsURL in this.specDirs[specName].results)) {
-              this.specDirs[specName].results[resultsURL] = {resultsURL: resultsURL, passing: 0, total: 0}
-            }
-            this.specDirs[specName].results[resultsURL].passing += testFiles[testFileName][0]
-            this.specDirs[specName].results[resultsURL].total += testFiles[testFileName][1]
-            if (!(testFileName in this.specDirs[specName].testFiles)) {
-              this.specDirs[specName].testFiles[testFileName] = {testFile: testFileName, results: {}}
-            }
-            if (!(resultsURL in this.specDirs[specName].testFiles[testFileName].results)) {
-              this.specDirs[specName].testFiles[testFileName].results[resultsURL] = {resultsURL: resultsURL, passing: 0, total: 0}
-            }
-            this.specDirs[specName].testFiles[testFileName].results[resultsURL].passing = testFiles[testFileName][0]
-            this.specDirs[specName].testFiles[testFileName].results[resultsURL].total = testFiles[testFileName][1]
-          })
         })
 
-        this._refreshDisplayedSpecDirs()
+        this._refreshDisplayedNodes()
       }
 
       _computePathIsATestFile (path) {
         return path.endsWith('.html') || path.endsWith('.htm')
-      }
-
-      _testFileSort (a, b) {
-        if (a.testFile < b.testFile) return -1
-        if (a.testFile > b.testFile) return 1
-        return 0
-      }
-
-      _specDirSort (a, b) {
-        if (a.specName < b.specName) return -1
-        if (a.specName > b.specName) return 1
-        return 0
       }
 
       _nodeSort (a, b) {
@@ -262,15 +217,14 @@ limitations under the License.
       }
 
       _queryChanged () {
-        this._refreshDisplayedSpecDirs()
+        this._refreshDisplayedNodes()
       }
 
-      _refreshDisplayedSpecDirs () {
+      _refreshDisplayedNodes () {
         /* Recomputes the list of displayed spec directories and their child test results. */
-
-        // EXPERIMENTAL
         const displayedNodeDict = {}
-        const matchesQueryng = (name) => name.toLowerCase().includes(this.query.toLowerCase())
+        // FIXME: add back search result matching
+        // const matchesQueryng = (name) => name.toLowerCase().includes(this.query.toLowerCase())
         const currentPathParts = this._splitIntoLinkedParts(this.path)
 
         const updateResults = (testFileName, dirPath, isDir) => {
@@ -316,72 +270,12 @@ limitations under the License.
             if (testFileName.includes('building-paths')) console.log(testFileName, dirParts, dirPath)
             updateResults(testFileName, dirPath, true)
           }
-
         })
         let displayedNodes = Object.keys(displayedNodeDict).map(key => (
           {path: key, isDir: displayedNodeDict[key].isDir, results: displayedNodeDict[key].results}
         ))
         displayedNodes.sort(this._nodeSort)
         this.displayedNodes = displayedNodes
-        return
-
-        // just a note this doesn't need to be recomputed every time, just the matching ones
-
-        // END EXPERIMENTAL
-
-        const matchesQuery = (tf) => tf.testFile.toLowerCase().includes(this.query.toLowerCase())
-        const displayedSpecDirs = []
-
-        for (var key in this.specDirs) {
-          let specDir = this.specDirs[key]
-          let displaySpecDir = {}
-
-          displaySpecDir.specName = specDir.specName
-          displaySpecDir.results = this.testRuns.map(testRun => specDir.results[testRun.results_url])
-
-          if (this.path !== '/') {
-            const inFilteredDir = this.path.startsWith(`/${displaySpecDir.specName}`)
-            if (!inFilteredDir) {
-              continue
-            }
-          }
-
-          if (this.query.length < 3 && this.path === '/') {
-            displaySpecDir.testFiles = []
-            displayedSpecDirs.push(displaySpecDir)
-            continue
-          }
-
-          let allTestFiles = Object.keys(specDir.testFiles).map(k => {
-            let displayTestFile = {}
-            let originalTestFile = specDir.testFiles[k]
-
-            displayTestFile.testFile = originalTestFile.testFile
-            displayTestFile.results = this.testRuns.map(testRun => originalTestFile.results[testRun.results_url])
-
-            return displayTestFile
-          })
-
-          const MAX_RESULTS_PER_SPEC_DIR = 10
-
-          let matchingTestFiles = allTestFiles.filter(matchesQuery)
-          if (matchingTestFiles.length > 0) {
-            if (this.path !== '/') {
-              displaySpecDir.testFiles = matchingTestFiles
-              displaySpecDir.testFiles = displaySpecDir.testFiles.filter(tf => (
-                tf.testFile.startsWith(this.path)
-              ))
-            } else {
-              displaySpecDir.testFiles = matchingTestFiles.slice(0, MAX_RESULTS_PER_SPEC_DIR)
-              displaySpecDir.notAllTestFilesShown = matchingTestFiles.length > MAX_RESULTS_PER_SPEC_DIR
-            }
-
-            displaySpecDir.testFiles.sort(this._testFileSort)
-            displayedSpecDirs.push(displaySpecDir)
-          }
-        }
-        displayedSpecDirs.sort(this._specDirSort)
-        this.set('displayedSpecDirs', displayedSpecDirs)
       }
 
       _platformID (testRun) {
@@ -396,7 +290,7 @@ limitations under the License.
         }
         this.path = path
         this.query = ''
-        this._refreshDisplayedSpecDirs()
+        this._refreshDisplayedNodes()
         window.history.pushState({}, '', path)
 
         // Send Google Analytics pageview event
@@ -439,14 +333,9 @@ limitations under the License.
         return path.replace(this.path + '/', '')
       }
 
-      _passingForNode (node, testRun) {
+      _resultForNode (node, testRun, property) {
         if (testRun.results_url in node.results) {
-          return node.results[testRun.results_url].passing
-        }
-      }
-      _totalForNode (node, testRun) {
-        if (testRun.results_url in node.results) {
-          return node.results[testRun.results_url].total
+          return node.results[testRun.results_url][property]
         }
       }
 

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -327,7 +327,6 @@ limitations under the License.
           return 'background-color: #eee'
         }
 
-
         // Need saturation between 65-100, reversed (range 35)
         const passRate = result.passing / result.total
         if (passRate === 1) {

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -104,7 +104,12 @@ limitations under the License.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <a href="{{ node.path }}" on-click="_navigate">{{ _relPath(node.path) }}</a>
+                <template is="dom-if" if="{{ node.isDir }}">
+                  <b><a href="{{ node.path }}" on-click="_navigate">{{ _relPath(node.path) }}</a></b>
+                </template>
+                <template is="dom-if" if="{{ !node.isDir }}">
+                  <a href="{{ node.path }}" on-click="_navigate">{{ _relPath(node.path) }}</a>
+                </template>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
@@ -114,37 +119,6 @@ limitations under the License.
             </tr>
           </template>
 
-          <!--
-          <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
-
-            <tr class="spec">
-              <td><b><a href="/{{specDir.specName}}" on-click="_navigate">{{specDir.specName}}</a></b></td>
-
-              <template is="dom-repeat" items="{{specDir.results}}" as="result">
-                <td>{{ result.passing }} / {{ result.total }}</td>
-              </template>
-            </tr>
-
-            <template is="dom-repeat" items="{{specDir.testFiles}}" as="testFile" class="test_file_list">
-              <tr>
-                <td>
-                  <template is="dom-repeat" items="{{ _splitIntoLinkedParts(testFile.testFile) }}" as="part"><span class="path-separator">/</span><a href="{{ part.path }}" on-click="_navigate">{{ part.name }}</a></template>
-                </td>
-
-                <template is="dom-repeat" items="{{testFile.results}}" as="result">
-                  <td style="{{ _testResultStyle(result) }}">
-                    {{ result.passing }}/{{ result.total }}
-                  </td>
-                </template>
-              </tr>
-            </template>
-
-            <template is="dom-if" if="{{ specDir.notAllTestFilesShown }}">
-              <a href="/{{ specDir.specName }}">See all files in the {{ specDir.specName }} spec</a>
-            </template>
-
-          </template>
-          -->
         </tbody>
       </table>
     </template>
@@ -190,7 +164,7 @@ limitations under the License.
           },
           displayedNodes: {
             type: Array,
-            value: [{path: 'cookies', isDir: true}, {path: 'atestfile.html', isDir: false}]
+            value: []
           }
         }
       }

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -108,7 +108,7 @@ limitations under the License.
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-                <td>{{ testRun.browser_name }}</td>
+                <td style="{{ _testResultStyle(node, testRun) }}">{{ _passingForNode(node, testRun) }} / {{ _totalForNode(node, testRun) }}</td>
               </template>
 
             </tr>
@@ -298,19 +298,58 @@ limitations under the License.
         const displayedNodeDict = {}
         const matchesQueryng = (name) => name.toLowerCase().includes(this.query.toLowerCase())
         const currentPathParts = this._splitIntoLinkedParts(this.path)
-        console.log(currentPathParts, this.path)
+
+        const updateResults = (testFileName, dirPath, isDir) => {
+          if (!(testFileName in displayedNodeDict)) {
+            displayedNodeDict[dirPath] = {isDir: isDir, results: {}}
+          }
+          let results = this.testFiles[testFileName]
+          Object.keys(results).forEach(resultURL => {
+            if (!(resultURL in displayedNodeDict[dirPath].results)) {
+              displayedNodeDict[dirPath].results[resultURL] = {passing: 0, total: 0}
+            }
+            displayedNodeDict[dirPath].results[resultURL].passing += results[resultURL][0]
+            displayedNodeDict[dirPath].results[resultURL].total += results[resultURL][1]
+          })
+        }
+
         Object.keys(this.testFiles).forEach(testFileName => {
-          if (testFileName.startsWith(this.path)) {
+          if (!testFileName.startsWith(this.path)) {
+            return
+          }
+          let parts = this._splitIntoLinkedParts(testFileName)
 
-            // console.log(this._splitIntoLinkedParts(testFileName), currentPathParts)
-            let parts = this._splitIntoLinkedParts(testFileName)
+          // Catch any top-level directories
+          if (this.path === '/' && parts.length === 2) {
+            let dirParts = [parts[0]]
+            let dirPath = dirParts[dirParts.length - 1].path
+            updateResults(testFileName, dirPath, true)
 
-            if (this.path === '/' && parts.length === 2) {
-              let dirParts = [parts[0]]
-              let dirPath = dirParts[dirParts.length - 1].path
-              displayedNodeDict[dirPath] = {isDir: true}
+          // Catch any test files in child directories
+          } else if (parts.length === currentPathParts.length + 1) {
+            let path = parts[parts.length - 1].path
+            updateResults(testFileName, path, false)
+
+          // Catch directories
+          } else if (parts.length > currentPathParts.length + 1) {
+            let dirParts
+            if (this.path === '/') {
+              dirParts = [parts[0]]
+            } else {
+              dirParts = parts.slice(0, currentPathParts.length + 1)
+            }
+            let dirPath = dirParts[dirParts.length - 1].path
+            updateResults(testFileName, dirPath, true)
+          }
+
+            /*
+            // Catch any test files in child directories
             } else if (parts.length === currentPathParts.length + 1) {
-              displayedNodeDict[testFileName] = {isDir: false}
+              //let dirParts = parts.slice(0, currentPathParts.length + 1)
+              // let dirPath = dirParts[dirParts.length - 1].path
+              // updateResults(testFileName, dirPath, false)
+
+            // Catch directories further down the tree
             } else if (parts.length > currentPathParts.length + 1) {
               let dirParts
               if (this.path === '/') {
@@ -319,13 +358,13 @@ limitations under the License.
                 dirParts = parts.slice(0, currentPathParts.length + 1)
               }
               let dirPath = dirParts[dirParts.length - 1].path
-              displayedNodeDict[dirPath] = {isDir: true}
+              // displayedNodeDict[dirPath] = {isDir: true, results: {}}
+              updateResults(testFileName, dirPath, true)
             }
-
-          }
+            */
         })
         let displayedNodes = Object.keys(displayedNodeDict).map(key => (
-          {path: key, isDir: displayedNodeDict[key].isDir}
+          {path: key, isDir: displayedNodeDict[key].isDir, results: displayedNodeDict[key].results}
         ))
         displayedNodes.sort(this._nodeSort)
         this.displayedNodes = displayedNodes
@@ -423,8 +462,11 @@ limitations under the License.
         })
       }
 
-      _testResultStyle (result) {
-        if (!result) return ''
+      _testResultStyle (node, testRun) {
+        if (!node) return
+        if (!testRun) return
+        if (!(testRun.results_url in node.results)) return
+        const result = node.results[testRun.results_url]
 
         // Need saturation between 65-100, reversed (range 35)
         const passRate = result.passing / result.total
@@ -440,6 +482,17 @@ limitations under the License.
 
       _relPath (path) {
         return path.replace(this.path + '/', '')
+      }
+
+      _passingForNode (node, testRun) {
+        if (testRun.results_url in node.results) {
+          return node.results[testRun.results_url].passing
+        }
+      }
+      _totalForNode (node, testRun) {
+        if (testRun.results_url in node.results) {
+          return node.results[testRun.results_url].total
+        }
       }
 
       /* Function for getting total numbers.

--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -101,6 +101,20 @@ limitations under the License.
         </thead>
         <tbody>
 
+          <template is="dom-repeat" items="{{displayedNodes}}" as="node">
+            <tr>
+              <td>
+                <a href="{{ node.path }}" on-click="_navigate">{{ _relPath(node.path) }}</a>
+              </td>
+
+              <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+                <td>{{ testRun.browser_name }}</td>
+              </template>
+
+            </tr>
+          </template>
+
+          <!--
           <template is="dom-repeat" items="{{displayedSpecDirs}}" as="specDir" id="spec_list">
 
             <tr class="spec">
@@ -130,6 +144,7 @@ limitations under the License.
             </template>
 
           </template>
+          -->
         </tbody>
       </table>
     </template>
@@ -168,6 +183,14 @@ limitations under the License.
           pathIsATestFile: {
             type: Boolean,
             computed: '_computePathIsATestFile(path)'
+          },
+          testFiles: {
+            type: Object,
+            value: {}
+          },
+          displayedNodes: {
+            type: Array,
+            value: [{path: 'cookies', isDir: true}, {path: 'atestfile.html', isDir: false}]
           }
         }
       }
@@ -187,6 +210,17 @@ limitations under the License.
         testFileResults.forEach(result => {
           const testFiles = result.testFiles
           const resultsURL = result.resultsURL
+
+          // EXPERIMENTAL
+
+          Object.keys(result.testFiles).forEach(testFileName => {
+            if (!(testFileName in this.testFiles)) {
+              this.testFiles[testFileName] = {}
+            }
+            this.testFiles[testFileName][resultsURL] = result.testFiles[testFileName]
+          })
+
+          // END EXPERIMENTAL
 
           Object.keys(result.testFiles).forEach(testFileName => {
             const specName = this._specFromTestPath(testFileName)
@@ -229,6 +263,12 @@ limitations under the License.
         return 0
       }
 
+      _nodeSort (a, b) {
+        if (a.path < b.path) return -1
+        if (a.path > b.path) return 1
+        return 0
+      }
+
       _resultWithRunIndex (results, runIndex) {
         for (var key in results) {
           if (results[key].runIndex === runIndex) {
@@ -253,6 +293,48 @@ limitations under the License.
 
       _refreshDisplayedSpecDirs () {
         /* Recomputes the list of displayed spec directories and their child test results. */
+
+        // EXPERIMENTAL
+        const displayedNodeDict = {}
+        const matchesQueryng = (name) => name.toLowerCase().includes(this.query.toLowerCase())
+        const currentPathParts = this._splitIntoLinkedParts(this.path)
+        console.log(currentPathParts, this.path)
+        Object.keys(this.testFiles).forEach(testFileName => {
+          if (testFileName.startsWith(this.path)) {
+
+            // console.log(this._splitIntoLinkedParts(testFileName), currentPathParts)
+            let parts = this._splitIntoLinkedParts(testFileName)
+
+            if (this.path === '/' && parts.length === 2) {
+              let dirParts = [parts[0]]
+              let dirPath = dirParts[dirParts.length - 1].path
+              displayedNodeDict[dirPath] = {isDir: true}
+            } else if (parts.length === currentPathParts.length + 1) {
+              displayedNodeDict[testFileName] = {isDir: false}
+            } else if (parts.length > currentPathParts.length + 1) {
+              let dirParts
+              if (this.path === '/') {
+                dirParts = [parts[0]]
+              } else {
+                dirParts = parts.slice(0, currentPathParts.length + 1)
+              }
+              let dirPath = dirParts[dirParts.length - 1].path
+              displayedNodeDict[dirPath] = {isDir: true}
+            }
+
+          }
+        })
+        let displayedNodes = Object.keys(displayedNodeDict).map(key => (
+          {path: key, isDir: displayedNodeDict[key].isDir}
+        ))
+        displayedNodes.sort(this._nodeSort)
+        this.displayedNodes = displayedNodes
+        return
+
+        // just a note this doesn't need to be recomputed every time, just the matching ones
+
+        // END EXPERIMENTAL
+
         const matchesQuery = (tf) => tf.testFile.toLowerCase().includes(this.query.toLowerCase())
         const displayedSpecDirs = []
 
@@ -354,6 +436,10 @@ limitations under the License.
           // Some shade of red
           return `background-color: hsl(0, 85%, ${luminance}%)`
         }
+      }
+
+      _relPath (path) {
+        return path.replace(this.path + '/', '')
       }
 
       /* Function for getting total numbers.


### PR DESCRIPTION
Previously when viewing a subdirectory (e.g. /css), the UI would show all test files in all subdirectories of that directory. This PR only shows immediate children of directories, so for instance, `/css` now only shows immediate subdirectories like `/css/css-grid-1`.

Preview up here:
https://limit-directories-dot-wptdashboard.appspot.com/

Fixes #57 
Fixes #60

TODO:

- [x] Get search back and working
- [x] Don't colorize tests on front page (it's basically a sea of red)
- [x] Going to `/css` still shows entries for `/css-paint-api/geometry-background-image-003.html`
- [x] Startup time is a little slower, can it be sped up? (it's actually faster, see below)

Performance impact on time to first usable render: -0.05%
- https://wptdashboard.appspot.com/
- https://limit-directories-dot-wptdashboard.appspot.com/ - 1.85 seconds