### PR TITLE
Add link to original test source file

### DIFF
--- a/components/wpt-results.html
+++ b/components/wpt-results.html
@@ -84,6 +84,7 @@ limitations under the License.
     </section>
 
     <template is="dom-if" if="{{ pathIsATestFile }}">
+      <a href$="https://github.com/w3c/web-platform-tests/blob/master/[[path]]" target="_blank">Jump to source file</a>
       <test-file-results
         test-runs="[[testRuns]]"
         test-file="[[path]]">


### PR DESCRIPTION
Add a simple link to the original source file on GitHub w3c/web-platform-tests

Fixes #91 
Fixes #49 